### PR TITLE
Added new events triggered on reset button press

### DIFF
--- a/include/mgos_provision.h
+++ b/include/mgos_provision.h
@@ -37,6 +37,10 @@ enum mgos_provision_event {
   MGOS_PROVISION_EV_STATE_CHANGED = MGOS_PROVISION_EV_BASE,
   /* Provisioning failed and reset is being performed. Arg: NULL */
   MGOS_PROVISION_EV_RESET,
+  /* Reset button was pressed. Arg: NULL */
+  MGOS_PROVISION_EV_RESET_BTN_PRESSED,
+  /* Reset button was pressed and not inhibited by uptime. Arg: NULL */
+  MGOS_PROVISION_EV_RESET_BTN_ACTIVATED,
 };
 
 struct mgos_provision_state_changed_arg {

--- a/src/mgos_provision_btn.c
+++ b/src/mgos_provision_btn.c
@@ -56,6 +56,8 @@ static void button_down_cb(int pin, void *arg) {
   int duration = mgos_sys_config_get_provision_btn_hold_ms();
   if (s_hold_timer != MGOS_INVALID_TIMER_ID) mgos_clear_timer(s_hold_timer);
 
+  mgos_event_trigger(MGOS_PROVISION_EV_RESET_BTN_PRESSED, NULL);
+
   /* Don't do anything if reset period ended */
   if ((mgos_sys_config_get_provision_btn_inhibit_after_s() > 0) &&
       (mgos_uptime() > mgos_sys_config_get_provision_btn_inhibit_after_s())) {
@@ -66,6 +68,9 @@ static void button_down_cb(int pin, void *arg) {
 
   LOG(LL_INFO, ("Button pressed, setting %d ms timer", duration));
   s_hold_timer = mgos_set_timer(duration, 0, button_timer_cb, arg);
+
+  mgos_event_trigger(MGOS_PROVISION_EV_RESET_BTN_ACTIVATED, NULL);
+
   (void) pin;
 }
 


### PR DESCRIPTION
I've added event that is triggered on simple reset button press without checking for how long it was pressed, so i can easily hook additional functionality to short momentary press of the same button.