### PR TITLE
Start timer when button is already pressed during boot

### DIFF
--- a/src/mgos_provision_btn.c
+++ b/src/mgos_provision_btn.c
@@ -102,6 +102,11 @@ bool mgos_provision_btn_init(void) {
                                      ? MGOS_GPIO_INT_EDGE_NEG
                                      : MGOS_GPIO_INT_EDGE_POS,
                                  50, button_down_cb, NULL);
+
+    /* Start timer when button is already pressed during boot */
+    if (mgos_gpio_read(pin) != mgos_sys_config_get_provision_btn_pull_up()) {
+      button_down_cb(pin, NULL);
+    }
   }
 
   return true;


### PR DESCRIPTION
It was rather confusing for users when manual says to "hold button for 10 seconds to reset", but it does not work when you start holding it too early during the boot process. So i check the button state once the interrupt is in place.